### PR TITLE
Fix duplicate lobby watcher thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -421,13 +421,6 @@ def main():
     threading.Thread(target=cs.watch_dms, args=(_dm_dispatcher,), daemon=True).start()
     log_once("DM", "DM watcher aktif.")
 
-    # Lobby grup mesajlarını izle → komutları işle
-    threading.Thread(
-        target=cs.watch_group_messages,
-        args=(lambda cid, body, frm: handle_group_command(cs, cid, body, frm, cfg), 1.5),
-        daemon=True
-    ).start()
-
     # Lobby & queue watcher (ID/solo/phase/readycheck logları)
     # Lobby grup mesajlarını izle → komutları işle
     threading.Thread(


### PR DESCRIPTION
## Summary
- remove the extra lobby watcher thread so group commands are handled exactly once
- keep the existing watcher configuration (interval/include_self/debug) in a single thread

## Testing
- python -m py_compile main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191682913c8330aca89c52ea38877d)