### PR TITLE
Restrict DM start command to lobby members

### DIFF
--- a/chat_service.py
+++ b/chat_service.py
@@ -248,6 +248,16 @@ class ChatService:
         j = self._lget("/lol-lobby/v2/lobby")
         return j.get("members", []) or []
 
+    def is_puuid_in_lobby(self, puuid: str | None) -> bool:
+        target = (puuid or "").lower().strip()
+        if not target:
+            return False
+        for member in self._lobby_members():
+            mp = (member.get("puuid") or "").lower().strip()
+            if mp and mp == target:
+                return True
+        return False
+
     def find_member_by_name(self, name: str) -> Optional[dict]:
         n = (name or "").strip().lower()
         for m in self._lobby_members():

--- a/main.py
+++ b/main.py
@@ -54,6 +54,9 @@ def handle_party_management_command(
     txt: str,
     from_name: str,
     send_feedback: Callable[[str], None],
+    *,
+    context: str = "group",
+    sender_puuid: Optional[str] = None,
 ) -> bool:
     text = (txt or "").strip()
     if not text:
@@ -67,6 +70,9 @@ def handle_party_management_command(
     # BASLAT / START
     if low in ("baslat", "start", "/l"):
         log_once("GRP-CMD", f"{from_name} → BASLAT")
+        if context == "dm" and not cs.is_puuid_in_lobby(sender_puuid):
+            reply("lobbye katilmadiginiz icin oyun baslatma yetkini bulunmamaktadir")
+            return True
         if cs.is_party_leader():
             reply("Matchmaking başlatılıyor…")
             ok = cs.start_matchmaking()
@@ -125,7 +131,14 @@ def handle_dm_party_command(cs: ChatService, friend_key: str, friend_name: str, 
         if msg:
             cs.dm_send(friend_key, msg)
 
-    return handle_party_management_command(cs, body, name, dm_feedback)
+    return handle_party_management_command(
+        cs,
+        body,
+        name,
+        dm_feedback,
+        context="dm",
+        sender_puuid=friend_key,
+    )
 
 
 # ------------ Grup komutları (Lobby sohbeti) ------------


### PR DESCRIPTION
## Summary
- add a lobby membership helper that can verify whether a PUUID is currently in the party
- block DM-based start commands from users who are not in the lobby and inform them that they lack permission

## Testing
- python -m py_compile $(git ls-files '*.py')


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191766eea08330a83ddfc960f9c083)