### PR TITLE
Add Telegram approval gate for busy lobby start requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An open-source utility that allows you to remotely manage the **League of Legend
 - Lobby & DM commands → real LCU operations
 - Auto-accept (accept as soon as the window opens)
 - Preferential auto-pick (e.g., shaco, teemo, trundle)
+- Telegram push + inline approval when you're marked Busy/Away and someone types **BASLAT** in lobby
 - Lightweight, single Python process
 
 ## Installation
@@ -43,6 +44,7 @@ Sohbetten gelen komutlarla (BASLAT, DURDUR, DEVRET, BAN, ANONS) **League of Lege
 - Lobby & DM komutları → gerçek LCU işlemleri
 - Auto-accept (pencere açılır açılmaz kabul)
 - Tercihli auto-pick (örn. shaco, teemo, trundle)
+- Durumun Meşgul/Uzaktayken lobide biri **BASLAT** yazarsa Telegram'dan onay isteği gönderir
 - Hafif, tek Python süreci
 
 ## Kurulum

--- a/chat_service.py
+++ b/chat_service.py
@@ -65,6 +65,17 @@ class ChatService:
             return []
         return r.json() or []
 
+    def my_presence(self) -> Dict:
+        """Aktif hesabın sohbet / presence bilgilerini döner."""
+        r = self._get("/lol-chat/v1/me")
+        if r and r.status_code == 200:
+            return r.json() or {}
+        return {}
+
+    def my_availability(self) -> str:
+        pres = self.my_presence() or {}
+        return (pres.get('availability') or pres.get('availabilityStatus') or '').lower()
+
     def list_friends_online(self) -> List[dict]:
         out = []
         for f in self.list_friends():

--- a/telegram_bridge.py
+++ b/telegram_bridge.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json, threading, asyncio
-from typing import Optional, Dict
+from typing import Optional, Dict, Callable
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, CallbackQueryHandler, ContextTypes, filters
 from utils import log_once
@@ -19,6 +19,7 @@ class TelegramBridge:
         self.topics: Dict[str, int] = self._load_topics()
         self.topic_to_friend: Dict[int, str] = {}
         self._rebuild_reverse_index()
+        self._start_callbacks: Dict[str, Callable[[bool], None]] = {}
 
     def _rebuild_reverse_index(self):
         topics = getattr(self, "topics", {}) or {}
@@ -44,6 +45,7 @@ class TelegramBridge:
         self.app.add_handler(CommandHandler("start", self._cmd_start))
         self.app.add_handler(CommandHandler(["to", "who", "friends"], self._cmd_router))
         self.app.add_handler(CallbackQueryHandler(self._on_select_friend, pattern=r"^to:"))
+        self.app.add_handler(CallbackQueryHandler(self._on_start_decision, pattern=r"^start:"))
         self.app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_text))
 
     def start_in_thread(self):
@@ -131,6 +133,34 @@ class TelegramBridge:
         await update.callback_query.answer()
         await update.effective_message.reply_text(f"Hedef: {self.cs.friend_display_name(key)}")
 
+    async def _on_start_decision(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if not await self._only_owner(update):
+            return
+        data = update.callback_query.data.split(':')
+        if len(data) != 3:
+            await update.callback_query.answer("Geçersiz veri", show_alert=True)
+            return
+        _, req_id, decision = data
+        cb = self._start_callbacks.pop(req_id, None)
+        if not cb:
+            await update.callback_query.answer("İstek bulunamadı", show_alert=True)
+            return
+        approved = (decision == 'ok')
+        await update.callback_query.answer("Kaydedildi")
+
+        def _fire():
+            try:
+                cb(approved)
+            except Exception as exc:
+                log_once("TG", f"start cb err: {exc}")
+
+        threading.Thread(target=_fire, daemon=True).start()
+        msg = "BASLAT isteği onaylandı" if approved else "BASLAT isteği reddedildi"
+        try:
+            await update.effective_message.reply_text(msg)
+        except Exception:
+            pass
+
     async def _on_text(self, update, context):
         if not await self._only_owner(update): return
         text = update.message.text
@@ -157,3 +187,40 @@ class TelegramBridge:
         if not (self._loop and self.app):
             log_once("TG", "loop not ready; dropping DM"); return
         asyncio.run_coroutine_threadsafe(_send(), self._loop)
+
+    def request_start_confirmation(
+        self,
+        request_id: str,
+        requester: str,
+        availability: str,
+        callback: Callable[[bool], None],
+    ) -> bool:
+        """Telegram üzerinden BASLAT isteği için onay ister."""
+
+        if not (self._loop and self.app):
+            log_once("TG", "loop not ready; BASLAT isteği gönderilemedi")
+            return False
+
+        self._start_callbacks[request_id] = callback
+        avail_txt = availability.upper() if availability else "bilinmiyor"
+
+        async def _send():
+            text = (
+                f"Lobby'de {requester} BASLAT yazdı. Durumun: {avail_txt}. Onaylıyor musun?"
+            )
+            kb = InlineKeyboardMarkup([
+                [
+                    InlineKeyboardButton("✅ Onayla", callback_data=f"start:{request_id}:ok"),
+                    InlineKeyboardButton("❌ Reddet", callback_data=f"start:{request_id}:no"),
+                ]
+            ])
+            await self.app.bot.send_message(chat_id=self.owner_id, text=text, reply_markup=kb)
+
+        fut = asyncio.run_coroutine_threadsafe(_send(), self._loop)
+        try:
+            fut.result(timeout=5)
+            return True
+        except Exception as exc:
+            log_once("TG", f"start request send err: {exc}")
+            self._start_callbacks.pop(request_id, None)
+            return False


### PR DESCRIPTION
## Summary
- add presence helpers plus a StartApprovalManager that can defer lobby BASLAT commands until the owner approves through Telegram when the account is marked busy/away
- extend the Telegram bridge with inline approval buttons and callbacks so that BASLAT requests can be approved or rejected directly from Telegram
- document the new behaviour in the README

## Testing
- python -m compileall main.py chat_service.py telegram_bridge.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d4f43d9883308f7a6bd5cd994d57)